### PR TITLE
Add envPath config option

### DIFF
--- a/util/secret.js
+++ b/util/secret.js
@@ -1,6 +1,8 @@
 const getConfig = require("./getConfig");
 const config = getConfig();
-require("dotenv").config();
+require("dotenv").config({
+  path: config.envPath || '.env'
+});
 
 const defaultSecret = "FAUNADB_SECRET";
 const { secretEnv = defaultSecret } = config;


### PR DESCRIPTION
Adds `envPath` config option in `.fauna.json`.

My use case for this is that in my next.js project I already have an `.env.local` file that has the `FAUNADB_SECRET`.