### PR TITLE
Make the config file optional

### DIFF
--- a/util/getConfig.js
+++ b/util/getConfig.js
@@ -3,7 +3,8 @@ const fs = require("fs");
 const cwd = process.cwd();
 
 function getConfig(){
-	return JSON.parse(fs.readFileSync(path.join(cwd, ".fauna.json"), "utf8"));
+	const configPath = path.join(cwd, ".fauna.json");
+	return fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
 }
 
 module.exports = getConfig;


### PR DESCRIPTION
Hi,
first of all thank you for this very useful tool!

I noticed that if you're happy with the defaults and don't create a `.fauna.json` config file, the CLI throws an error. This is a small PR to fix that.