### PR TITLE
Add support for asynchronous resources

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -15,9 +15,9 @@ async function uploadResources(resourceDir, type){
 		return;
 	}
 
-	const resourceFiles = files.map( file => {
+	const resourceFiles = (await Promise.all(files.map( async file => {
 		try{
-			const resource = require(path.join(cwd, resourceDir, file));
+			const resource = await require(path.join(cwd, resourceDir, file));
 
 			return resource;
 		}catch(err){
@@ -26,7 +26,7 @@ async function uploadResources(resourceDir, type){
 
 			return null;
 		}
-	}).filter( value => value !== null);
+	}))).filter( value => value !== null);
 
 	try{
 		await createOrUpdateResources(resourceFiles, type);
@@ -37,7 +37,7 @@ async function uploadResources(resourceDir, type){
 		displayErrors(err, type);
 		console.log();
 	}
-	
+
 }
 
 async function setResources(resources, type){


### PR DESCRIPTION
This PR adds support for asynchronous modules in the resource directories.

This is mostly useful for data resources, e.g. to fetch some mocking data from an external API (like https://jsonplaceholder.typicode.com or https://loripsum.net) or to fetch some data from a legacy database to test it in a new environment.