### PR TITLE
Default exports

### DIFF
--- a/util/createOrUpdateResources.js
+++ b/util/createOrUpdateResources.js
@@ -9,15 +9,17 @@ const createFunctionsWithoutRoles = require("./createFunctionsWithoutRoles");
  * @param {{ fnsWithRoles: boolean }} options - Additional options
  */
 async function createOrUpdateResources(resources, type, { fnsWithRoles = true } = {}){
+	const resourcesArray = resources.map(r => r.default || r); // Support default exports
+
 	if (type === 'data') {
-		return createOrUpdateData(resources);
+		return createOrUpdateData(resourcesArray);
 	}
 
 	if(type === "functions" && !fnsWithRoles){
-		return createFunctionsWithoutRoles(resources);
+		return createFunctionsWithoutRoles(resourcesArray);
 	}
 
-	return createOrUpdateStandardResources(resources, type);
+	return createOrUpdateStandardResources(resourcesArray, type);
 }
 
 module.exports = createOrUpdateResources;


### PR DESCRIPTION
Adds support for this syntax in TypeScript:
```
// fauna/functions/Example.ts
const Example = {
  name: "test",
  body: Query(Lambda([], Debug({ foo: "bar" }))),
};

export default Example;
```

There may be a more elegant way to do this but I ran into issues with the Next.js default template coercing me into `export default` via this error:

```
Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
```