### PR TITLE
Fix TypeScript uploads

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -6,6 +6,8 @@ const esbuild = require("esbuild");
 
 const cwd = process.cwd();
 
+const allowedExts = ['.js', '.ts']
+
 async function uploadResources(dir, type, options){
 	const failedUploadError = `❌  Failed to upload ${type}\n`;
 
@@ -20,7 +22,6 @@ async function uploadResources(dir, type, options){
 
 	const entries = files.filter(file =>{
 		const ext = getExt(file)
-		const allowedExts = ['.js', '.ts']
 
 		if(allowedExts.includes(ext)){
 			return true
@@ -62,7 +63,7 @@ async function uploadResources(dir, type, options){
 
 	const resourceFiles = (await Promise.all(files.map( async file => {
 		try{
-			if(getExt(file) !== ".js") return null;
+			if(allowedExts.includes(getExt(file))) return null;
 			const resourcePath = path.join(cwd, resourceDir, removeExt(file) + ".js");
 			const resource = await require(resourcePath);
 


### PR DESCRIPTION
I noticed my `.ts` files weren't pushing to Fauna. It took me a bit to track it down but I believe [this commit](https://github.com/Plazide/fauna-gql-upload/commit/a6418097b97e7d4b5ba13c548d6e8fcd256e2e29) causes `.ts` files to be ignored.