### PR TITLE
Update graphql-code-generator.md

### DIFF
--- a/docs/usage/graphql-code-generator.md
+++ b/docs/usage/graphql-code-generator.md
@@ -40,7 +40,7 @@ and then adding it to the `.fauna.json` file, like so:
 ```js
 {
   "codegen": {
-    "plugins": "typescript-react-apollo"
+    "plugins": ["typescript-react-apollo"]
   }
 }
 ```


### PR DESCRIPTION
`plugins` should be an array. Otherwise you'll see an error: `TypeError: customPlugins.map is not a function`.